### PR TITLE
Change namespace from Cbra to Cobra

### DIFF
--- a/bin/cobratest
+++ b/bin/cobratest
@@ -40,8 +40,8 @@ if option
   if %w(--help -h -H).include? option
     puts help_text
   elsif %w(-r --results).include? option
-    Cbratest::Runner.new(false).run path
+    Cobratest::Runner.new(false).run path
   elsif %w(-v --verbose).include? option
-    Cbratest::Runner.new(true).run path
+    Cobratest::Runner.new(true).run path
   end
 end

--- a/lib/cobratest.rb
+++ b/lib/cobratest.rb
@@ -1,7 +1,7 @@
 require 'set'
 require 'pathname'
 
-module Cbratest
+module Cobratest
   require_relative "cobratest/gemfile_scraper"
   require_relative "cobratest/affected_component_finder"
   require_relative "cobratest/transitive_affected_component_finder"

--- a/lib/cobratest.rb
+++ b/lib/cobratest.rb
@@ -45,11 +45,11 @@ module Cobratest
     private
 
     def outputs(arg, even_non_verbose = false)
+      @output << arg
       output(arg) if even_non_verbose || @verbose_output
     end
 
     def output(arg)
-      @output << arg
       puts arg
     end
 

--- a/lib/cobratest.rb
+++ b/lib/cobratest.rb
@@ -10,6 +10,7 @@ module Cobratest
   class Runner
     def initialize(verbose_output)
       @verbose_output = verbose_output
+      @output = []
     end
 
     def run(root_path)
@@ -38,6 +39,7 @@ module Cobratest
 
       outputs "\nTest scripts to run"
       outputs all_in_need_of_running = TestsToRunSelector.new.list(all_affected), true
+      @output
     end
 
     private
@@ -47,6 +49,7 @@ module Cobratest
     end
 
     def output(arg)
+      @output << arg
       puts arg
     end
 

--- a/lib/cobratest/affected_component_finder.rb
+++ b/lib/cobratest/affected_component_finder.rb
@@ -1,4 +1,4 @@
-module Cbratest
+module Cobratest
   class AffectedComponentFinder
     def find(components, changes)
       components.inject({}) do |memo, component|

--- a/lib/cobratest/gemfile_scraper.rb
+++ b/lib/cobratest/gemfile_scraper.rb
@@ -1,4 +1,4 @@
-module Cbratest
+module Cobratest
   class GemfileScraper
     def initialize(root_path)
       @root_path = root_path

--- a/lib/cobratest/tests_to_run_selector.rb
+++ b/lib/cobratest/tests_to_run_selector.rb
@@ -1,4 +1,4 @@
-module Cbratest
+module Cobratest
   class TestsToRunSelector
     def list(affected)
       affected.keys.inject([]) do |memo, key|

--- a/lib/cobratest/transitive_affected_component_finder.rb
+++ b/lib/cobratest/transitive_affected_component_finder.rb
@@ -1,4 +1,4 @@
-module Cbratest
+module Cobratest
   class TransitiveAffectedComponentFinder
     def find(affected)
       all_affected = {}

--- a/spec/cobratest/affected_component_finder_spec.rb
+++ b/spec/cobratest/affected_component_finder_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
-describe Cbratest::AffectedComponentFinder do
+describe Cobratest::AffectedComponentFinder do
   describe '#find' do
     it 'includes a component if one of its files has been changed' do
-      expect(Cbratest::AffectedComponentFinder.new.find(
+      expect(Cobratest::AffectedComponentFinder.new.find(
                  [{name: "name", options: {path: '/some/path'}}],
                  ['/some/path/under/the/other']
              )).to eq (
@@ -12,7 +12,7 @@ describe Cbratest::AffectedComponentFinder do
     end
 
     it 'does not include a component if none of its files has been changed' do
-      expect(Cbratest::AffectedComponentFinder.new.find(
+      expect(Cobratest::AffectedComponentFinder.new.find(
                  [{name: "name", options: {path: '/some/path'}}],
                  ['/some/other/path']
              )).to eq (

--- a/spec/cobratest/cobratest_spec.rb
+++ b/spec/cobratest/cobratest_spec.rb
@@ -1,17 +1,11 @@
 require 'spec_helper'
 
 describe Cobratest do
-  before do
-    @puts = []
-    Cobratest::Runner.any_instance.stub(:output) do |arg|
-      @puts << arg
-    end
-  end
 
   it "outputs all affected components in verbose mode" do
     start_path = File.expand_path(File.join(__FILE__, "..", "..", "..", "spec", "examples", "letters"))
 
-    Cobratest::Runner.new(true).run(File.join(start_path, 'A'))
+    @puts = Cobratest::Runner.new(true).run(File.join(start_path, 'A'))
     expect(@puts).to eq(
                          [
                              "All components",

--- a/spec/cobratest/cobratest_spec.rb
+++ b/spec/cobratest/cobratest_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
-describe Cbratest do
+describe Cobratest do
   before do
     @puts = []
-    Cbratest::Runner.any_instance.stub(:output) do |arg|
+    Cobratest::Runner.any_instance.stub(:output) do |arg|
       @puts << arg
     end
   end
@@ -11,7 +11,7 @@ describe Cbratest do
   it "outputs all affected components in verbose mode" do
     start_path = File.expand_path(File.join(__FILE__, "..", "..", "..", "spec", "examples", "letters"))
 
-    Cbratest::Runner.new(true).run(File.join(start_path, 'A'))
+    Cobratest::Runner.new(true).run(File.join(start_path, 'A'))
     expect(@puts).to eq(
                          [
                              "All components",

--- a/spec/cobratest/cobratest_spec.rb
+++ b/spec/cobratest/cobratest_spec.rb
@@ -5,7 +5,7 @@ describe Cobratest do
   it "outputs all affected components in verbose mode" do
     start_path = File.expand_path(File.join(__FILE__, "..", "..", "..", "spec", "examples", "letters"))
 
-    @puts = Cobratest::Runner.new(true).run(File.join(start_path, 'A'))
+    @puts = Cobratest::Runner.new(false).run(File.join(start_path, 'A'))
     expect(@puts).to eq(
                          [
                              "All components",

--- a/spec/cobratest/gemfile_scraper_spec.rb
+++ b/spec/cobratest/gemfile_scraper_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Cbratest::GemfileScraper do
+describe Cobratest::GemfileScraper do
   it "'s name is the last part of the given path" do
     expect(described_class.new("some/path_with/a/special_name").name).to eq "special_name"
   end

--- a/spec/cobratest/tests_to_run_selector_spec.rb
+++ b/spec/cobratest/tests_to_run_selector_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
-describe Cbratest::TestsToRunSelector do
+describe Cobratest::TestsToRunSelector do
   describe '#list' do
     it 'includes a test runner if a component is marked as changed' do
-      expect(Cbratest::TestsToRunSelector.new.list(
+      expect(Cobratest::TestsToRunSelector.new.list(
                  {{:name => "name", :options => {:path => "/some/path"}} => true}
              )).to eq (
                           ["/some/path/test.sh"]
@@ -11,7 +11,7 @@ describe Cbratest::TestsToRunSelector do
     end
 
     it 'does not include a test runner if a component is marked as not changed' do
-      expect(Cbratest::TestsToRunSelector.new.list(
+      expect(Cobratest::TestsToRunSelector.new.list(
                  {{:name => "name", :options => {:path => "/some/path"}} => false}
              )).to eq (
                           []

--- a/spec/cobratest/transitive_affected_component_finder_spec.rb
+++ b/spec/cobratest/transitive_affected_component_finder_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
-describe Cbratest::TransitiveAffectedComponentFinder do
+describe Cobratest::TransitiveAffectedComponentFinder do
   describe '#find' do
     it 'marks components as affected that depend on affected components' do
       path = File.expand_path(File.join(__FILE__, "..", "..", "..", "spec", "examples", "letters"))
 
-      expect(Cbratest::TransitiveAffectedComponentFinder.new.find(
+      expect(Cobratest::TransitiveAffectedComponentFinder.new.find(
                  {
                      {name: 'A', options: {path: File.join(path, 'A')}} => false,
                      {name: 'B', options: {path: File.join(path, 'B')}} => true,
@@ -23,7 +23,7 @@ describe Cbratest::TransitiveAffectedComponentFinder do
     it 'does not unmark components that once they are marked' do
       path = File.expand_path(File.join(__FILE__, "..", "..", "..", "spec", "examples", "letters"))
 
-      expect(Cbratest::TransitiveAffectedComponentFinder.new.find(
+      expect(Cobratest::TransitiveAffectedComponentFinder.new.find(
                  {
                      {name: 'A', options: {path: File.join(path, 'A')}} => true,
                      {name: 'B', options: {path: File.join(path, 'B')}} => false,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,6 @@
 require_relative '../lib/cobratest'
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
   config.order = 'random'


### PR DESCRIPTION
Considering your last commits, I changed all references from Cbratest to Cobratest

Used this little one liner to do the job

``` bash
while read file; do sed -i '' 's/Cbra/Cobra/' $file; done < <(fgrep "Cbra" *|cut -d":" -f1|sort -d|uniq)
```

bonus: Fix the test without using allow_any_instance_of ;)
