### PR TITLE
Catch components within Gemfile path block

### DIFF
--- a/cobratest.gemspec
+++ b/cobratest.gemspec
@@ -29,7 +29,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.5'
+  spec.add_dependency 'bundler', '~> 1.13'
+
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
 end

--- a/lib/cobratest/gemfile_scraper.rb
+++ b/lib/cobratest/gemfile_scraper.rb
@@ -56,8 +56,12 @@ module Cbratest
       gemfile_path = File.join(@root_path, "Gemfile")
       lockfile_path = File.join(@root_path, "Gemfile.lock")
       ::Bundler::Definition.build(gemfile_path, lockfile_path, nil).dependencies.inject([]) do |memo, dep|
-        path = dep.source.path.to_s if dep.source
-        path = nil if path == "."
+        path = dep.source.path.to_s if dep.source && dep.source.is_a_path?
+        if path == "."
+          path = nil
+        elsif path && !path.match(/#{dep.name}/)
+          path = "#{path}/#{dep.name}"
+        end
         memo << { name: dep.name, options: { path: path }}
         memo
       end

--- a/lib/cobratest/gemfile_scraper.rb
+++ b/lib/cobratest/gemfile_scraper.rb
@@ -1,3 +1,5 @@
+require "bundler"
+
 module Cbratest
   class GemfileScraper
     def initialize(root_path)
@@ -51,11 +53,12 @@ module Cbratest
     end
 
     def gem_dependencies
-      raw_gemfile.split("\n").inject([]) do |memo, line|
-        match = line.match(/gem\s+["']([^'"]+)["'](.*)/)
-        if match
-          memo << {name: match[1], options: OptionParser.new(match[2]).parse}
-        end
+      gemfile_path = File.join(@root_path, "Gemfile")
+      lockfile_path = File.join(@root_path, "Gemfile.lock")
+      ::Bundler::Definition.build(gemfile_path, lockfile_path, nil).dependencies.inject([]) do |memo, dep|
+        path = dep.source.path.to_s if dep.source
+        path = nil if path == "."
+        memo << { name: dep.name, options: { path: path }}
         memo
       end
     end

--- a/spec/cobratest/gemfile_scraper_spec.rb
+++ b/spec/cobratest/gemfile_scraper_spec.rb
@@ -29,25 +29,22 @@ describe Cbratest::GemfileScraper do
 
       scraper = described_class.new(start_path)
       expect(scraper.transitive_cobra_dependencies).to eq([
-                                                             {:name => "E1",
-                                                              :options =>
-                                                                  {
-                                                                      :path => File.join(expected_base_path, "E1")
-                                                                  }
-                                                             },
-                                                             {:name => "E2",
-                                                              :options =>
-                                                                  {
-                                                                      :path => File.join(expected_base_path, "E2")
-                                                                  }
-                                                             },
-                                                             {:name => "F",
-                                                              :options =>
-                                                                  {
-                                                                      :path => File.join(expected_base_path, "F")
-                                                                  }
-                                                             }
-                                                         ])
+        {:name => "E1",
+          :options => {
+            :path => File.join(expected_base_path, "E1")
+          }
+        },
+        {:name => "E2",
+          :options => {
+            :path => File.join(expected_base_path, "E2")
+          }
+        },
+        {:name => "F",
+          :options => {
+            :path => File.join(expected_base_path, "F")
+          }
+        }
+      ])
     end
   end
 end

--- a/spec/examples/letters/B/Gemfile
+++ b/spec/examples/letters/B/Gemfile
@@ -6,8 +6,5 @@ gemspec
 gem "C", path: "../C"
 gem "D", path: "../D"
 gem "E1", path: "../E1"
-
-path ".." do
-  gem "E2"
-  gem "F"
-end
+gem "E2", path: "../E2"
+gem "F", path: "../F"

--- a/spec/examples/letters/B/Gemfile
+++ b/spec/examples/letters/B/Gemfile
@@ -6,5 +6,8 @@ gemspec
 gem "C", path: "../C"
 gem "D", path: "../D"
 gem "E1", path: "../E1"
-gem "E2", path: "../E2"
-gem "F", path: "../F"
+
+path ".." do
+  gem "E2"
+  gem "F"
+end

--- a/spec/examples/letters/B/b.gemspec
+++ b/spec/examples/letters/B/b.gemspec
@@ -7,8 +7,8 @@ Gem::Specification.new do |spec|
   spec.version       = "0.0.1"
   spec.authors       = ["Stephan Hagemann"]
   spec.email         = ["stephan.hagemann@gmail.com"]
-  spec.summary       = %q{TODO: Write a short summary. Required.}
-  spec.description   = %q{TODO: Write a longer description. Optional.}
+  spec.summary       = %q{Some Summary}
+  spec.description   = %q{A longer description}
   spec.homepage      = ""
   spec.license       = "MIT"
 

--- a/spec/examples/letters/B/b.gemspec
+++ b/spec/examples/letters/B/b.gemspec
@@ -1,11 +1,10 @@
 # coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'B/version'
 
 Gem::Specification.new do |spec|
   spec.name          = "B"
-  spec.version       = B::VERSION
+  spec.version       = "0.0.1"
   spec.authors       = ["Stephan Hagemann"]
   spec.email         = ["stephan.hagemann@gmail.com"]
   spec.summary       = %q{TODO: Write a short summary. Required.}

--- a/spec/examples/letters/C/c.gemspec
+++ b/spec/examples/letters/C/c.gemspec
@@ -7,8 +7,8 @@ Gem::Specification.new do |spec|
   spec.version       = '0.0.1'
   spec.authors       = ["Stephan Hagemann"]
   spec.email         = ["stephan.hagemann@gmail.com"]
-  spec.summary       = %q{TODO: Write a short summary. Required.}
-  spec.description   = %q{TODO: Write a longer description. Optional.}
+  spec.summary       = %q{Some Summary}
+  spec.description   = %q{A longer description}
   spec.homepage      = ""
   spec.license       = "MIT"
 

--- a/spec/examples/letters/C/c.gemspec
+++ b/spec/examples/letters/C/c.gemspec
@@ -1,11 +1,10 @@
 # coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'C/version'
 
 Gem::Specification.new do |spec|
   spec.name          = "C"
-  spec.version       = C::VERSION
+  spec.version       = '0.0.1'
   spec.authors       = ["Stephan Hagemann"]
   spec.email         = ["stephan.hagemann@gmail.com"]
   spec.summary       = %q{TODO: Write a short summary. Required.}

--- a/spec/examples/letters/D/Gemfile
+++ b/spec/examples/letters/D/Gemfile
@@ -5,5 +5,9 @@ gemspec
 
 gem "E1", path: "../E1"
 gem "E2", path: "../E2"
-gem "F", path: "../F"
-  
+
+gem "cobradeps", github: "shageman/cobradeps"
+
+path ".." do
+  gem "F"
+end

--- a/spec/examples/letters/D/d.gemspec
+++ b/spec/examples/letters/D/d.gemspec
@@ -7,8 +7,8 @@ Gem::Specification.new do |spec|
   spec.version       = "0.0.1"
   spec.authors       = ["Stephan Hagemann"]
   spec.email         = ["stephan.hagemann@gmail.com"]
-  spec.summary       = %q{TODO: Write a short summary. Required.}
-  spec.description   = %q{TODO: Write a longer description. Optional.}
+  spec.summary       = %q{Some Summary}
+  spec.description   = %q{A longer description}
   spec.homepage      = ""
   spec.license       = "MIT"
 

--- a/spec/examples/letters/D/d.gemspec
+++ b/spec/examples/letters/D/d.gemspec
@@ -1,11 +1,10 @@
 # coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'D/version'
 
 Gem::Specification.new do |spec|
   spec.name          = "D"
-  spec.version       = D::VERSION
+  spec.version       = "0.0.1"
   spec.authors       = ["Stephan Hagemann"]
   spec.email         = ["stephan.hagemann@gmail.com"]
   spec.summary       = %q{TODO: Write a short summary. Required.}

--- a/spec/examples/letters/E1/e1.gemspec
+++ b/spec/examples/letters/E1/e1.gemspec
@@ -7,8 +7,8 @@ Gem::Specification.new do |spec|
   spec.version       = "0.0.1"
   spec.authors       = ["Stephan Hagemann"]
   spec.email         = ["stephan.hagemann@gmail.com"]
-  spec.summary       = %q{TODO: Write a short summary. Required.}
-  spec.description   = %q{TODO: Write a longer description. Optional.}
+  spec.summary       = %q{Some Summary}
+  spec.description   = %q{A longer description}
   spec.homepage      = ""
   spec.license       = "MIT"
 

--- a/spec/examples/letters/E1/e1.gemspec
+++ b/spec/examples/letters/E1/e1.gemspec
@@ -1,11 +1,10 @@
 # coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'E1/version'
 
 Gem::Specification.new do |spec|
   spec.name          = "E1"
-  spec.version       = E1::VERSION
+  spec.version       = "0.0.1"
   spec.authors       = ["Stephan Hagemann"]
   spec.email         = ["stephan.hagemann@gmail.com"]
   spec.summary       = %q{TODO: Write a short summary. Required.}

--- a/spec/examples/letters/E2/e2.gemspec
+++ b/spec/examples/letters/E2/e2.gemspec
@@ -7,8 +7,8 @@ Gem::Specification.new do |spec|
   spec.version       = "0.0.1"
   spec.authors       = ["Stephan Hagemann"]
   spec.email         = ["stephan.hagemann@gmail.com"]
-  spec.summary       = %q{TODO: Write a short summary. Required.}
-  spec.description   = %q{TODO: Write a longer description. Optional.}
+  spec.summary       = %q{Some Summary}
+  spec.description   = %q{A longer description}
   spec.homepage      = ""
   spec.license       = "MIT"
 

--- a/spec/examples/letters/E2/e2.gemspec
+++ b/spec/examples/letters/E2/e2.gemspec
@@ -1,11 +1,10 @@
 # coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'E2/version'
 
 Gem::Specification.new do |spec|
   spec.name          = "E2"
-  spec.version       = E2::VERSION
+  spec.version       = "0.0.1"
   spec.authors       = ["Stephan Hagemann"]
   spec.email         = ["stephan.hagemann@gmail.com"]
   spec.summary       = %q{TODO: Write a short summary. Required.}

--- a/spec/examples/letters/F/f.gemspec
+++ b/spec/examples/letters/F/f.gemspec
@@ -7,8 +7,8 @@ Gem::Specification.new do |spec|
   spec.version       = "0.0.1"
   spec.authors       = ["Stephan Hagemann"]
   spec.email         = ["stephan.hagemann@gmail.com"]
-  spec.summary       = %q{TODO: Write a short summary. Required.}
-  spec.description   = %q{TODO: Write a longer description. Optional.}
+  spec.summary       = %q{Some Summary}
+  spec.description   = %q{A longer description}
   spec.homepage      = ""
   spec.license       = "MIT"
 

--- a/spec/examples/letters/F/f.gemspec
+++ b/spec/examples/letters/F/f.gemspec
@@ -1,11 +1,10 @@
 # coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'F/version'
 
 Gem::Specification.new do |spec|
   spec.name          = "F"
-  spec.version       = F::VERSION
+  spec.version       = "0.0.1"
   spec.authors       = ["Stephan Hagemann"]
   spec.email         = ["stephan.hagemann@gmail.com"]
   spec.summary       = %q{TODO: Write a short summary. Required.}


### PR DESCRIPTION
In our application, we're including components in the Gemfile using block syntax, like so:

```ruby
path "components" do
  gem "A"
  gem "B"
end
```

`cobratest`'s existing Gemfile parser was not mature enough to understand that this is the same thing as:

```ruby
gem "A", path: "components/A"
gem "B", path: "components/B"
```

This change covers both cases by using Bundler's parser itself.