### PR TITLE
Update rspec syntax to fix verbose spec

### DIFF
--- a/spec/cobratest/cobratest_spec.rb
+++ b/spec/cobratest/cobratest_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Cbratest do
   before do
     @puts = []
-    Cbratest::Runner.any_instance.stub(:output) do |arg|
+    allow_any_instance_of(Cbratest::Runner).to receive(:output) do |obj, arg|
       @puts << arg
     end
   end
@@ -13,26 +13,26 @@ describe Cbratest do
 
     Cbratest::Runner.new(true).run(File.join(start_path, 'A'))
     expect(@puts).to eq(
-                         [
-                             "All components",
-                             [
-                                 "B    #{start_path}/B",
-                                 "C    #{start_path}/C",
-                                 "D    #{start_path}/D",
-                                 "E1   #{start_path}/E1",
-                                 "E2   #{start_path}/E2",
-                                 "F    #{start_path}/F",
-                                 "A    #{start_path}/A"
-                             ],
-                             "\nChanges since last commit",
-                             [],
-                             "\nDirectly affected components",
-                             [],
-                             "\nTransitively affected components",
-                             [],
-                             "\nTest scripts to run",
-                             []
-                         ]
-                     )
+      [
+        "All components",
+        [
+          "B    #{start_path}/B",
+          "C    #{start_path}/C",
+          "D    #{start_path}/D",
+          "E1   #{start_path}/E1",
+          "E2   #{start_path}/E2",
+          "F    #{start_path}/F",
+          "A    #{start_path}/A"
+        ],
+        "\nChanges since last commit",
+        [],
+        "\nDirectly affected components",
+        [],
+        "\nTransitively affected components",
+        [],
+        "\nTest scripts to run",
+        []
+      ]
+    )
   end
 end


### PR DESCRIPTION
Rspec-mocks block syntax has changed. Instead of catching the output of `any_instance` in the first arg, it now catches it in the second arg.

Before this fix, the spec failed like this:

```bash
$ rspec spec/cobratest/cobratest_spec.rb
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 36488
F

Failures:

  1) Cbratest outputs all affected components in verbose mode
     Failure/Error:
       expect(@puts).to eq(
                            [
                                "All components",
                                [
                                    "B    #{start_path}/B",
                                    "C    #{start_path}/C",
                                    "D    #{start_path}/D",
                                    "E1   #{start_path}/E1",
                                    "E2   #{start_path}/E2",
                                    "F    #{start_path}/F",

       expected: ["All components", ["B    /Users/garettarrowood/Power/cobratest/spec/examples/letters/B", "C    /User...tly affected components", [], "\nTransitively affected components", [], "\nTest scripts to run", []]
            got: [#<Cbratest::Runner:0x007fef5b8778f8 @verbose_output=true>, #<Cbratest::Runner:0x007fef5b8778f8 @verb...r:0x007fef5b8778f8 @verbose_output=true>, #<Cbratest::Runner:0x007fef5b8778f8 @verbose_output=true>]

       (compared using ==)

       Diff:
       @@ -1,17 +1,11 @@
       -["All components",
       - ["B    /Users/garettarrowood/Power/cobratest/spec/examples/letters/B",
       -  "C    /Users/garettarrowood/Power/cobratest/spec/examples/letters/C",
       -  "D    /Users/garettarrowood/Power/cobratest/spec/examples/letters/D",
       -  "E1   /Users/garettarrowood/Power/cobratest/spec/examples/letters/E1",
       -  "E2   /Users/garettarrowood/Power/cobratest/spec/examples/letters/E2",
       -  "F    /Users/garettarrowood/Power/cobratest/spec/examples/letters/F",
       -  "A    /Users/garettarrowood/Power/cobratest/spec/examples/letters/A"],
       - "\nChanges since last commit",
       - [],
       - "\nDirectly affected components",
       - [],
       - "\nTransitively affected components",
       - [],
       - "\nTest scripts to run",
       - []]
       +[#<Cbratest::Runner:0x007fef5b8778f8 @verbose_output=true>,
       + #<Cbratest::Runner:0x007fef5b8778f8 @verbose_output=true>,
       + #<Cbratest::Runner:0x007fef5b8778f8 @verbose_output=true>,
       + #<Cbratest::Runner:0x007fef5b8778f8 @verbose_output=true>,
       + #<Cbratest::Runner:0x007fef5b8778f8 @verbose_output=true>,
       + #<Cbratest::Runner:0x007fef5b8778f8 @verbose_output=true>,
       + #<Cbratest::Runner:0x007fef5b8778f8 @verbose_output=true>,
       + #<Cbratest::Runner:0x007fef5b8778f8 @verbose_output=true>,
       + #<Cbratest::Runner:0x007fef5b8778f8 @verbose_output=true>,
       + #<Cbratest::Runner:0x007fef5b8778f8 @verbose_output=true>]

     # ./spec/cobratest/cobratest_spec.rb:15:in `block (2 levels) in <top (required)>'
```