### PR TITLE
Implement --since option to target branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,16 +18,15 @@ Or install it yourself as:
 
 ## Usage
 
-cobratest [OPTION] [application path]
+    cobratest [OPTION] [application path]
 
-Test runner employing the structure of Component-based Ruby/Rails apps to optimize what needs to run.
+    Test runner employing the structure of Component-based Ruby/Rails apps to optimize what needs to run.
 
-Options are...
-    -h, -H, --help                   Display this help message.
-
-    -r, --results                    DEFAULT Display the directories of the components in need of running tests
-    -v, --verbose                    Verbose output of all parts of the calculation
-    -s, --since BRANCH               Specify BRANCH target to calculate against
+    Options are...
+        -h, -H, --help                   Display this help message.
+        -r, --results                    DEFAULT Display the directories of the components in need of running tests
+        -v, --verbose                    Verbose output of all parts of the calculation
+        -s, --since BRANCH               Specify BRANCH target to calculate against
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -18,15 +18,16 @@ Or install it yourself as:
 
 ## Usage
 
-    cobratest [OPTION] [application path]
+cobratest [OPTION] [application path]
 
-    Test runner employing the structure of Component-based Ruby/Rails apps to optimize what needs to run.
+Test runner employing the structure of Component-based Ruby/Rails apps to optimize what needs to run.
 
-    Options are...
-        -h, -H, --help                   Display this help message.
+Options are...
+    -h, -H, --help                   Display this help message.
 
-        -r, --results                    DEFAULT Display the directories of the components in need of running tests
-        -v, --verbose                    Verbose output of all parts of the calculation
+    -r, --results                    DEFAULT Display the directories of the components in need of running tests
+    -v, --verbose                    Verbose output of all parts of the calculation
+    -s, --since BRANCH               Specify BRANCH target to calculate against
 
 ## Example
 
@@ -71,10 +72,8 @@ In verbose mode one can check the correctness of cobratest's calculation:
     ./cobra/cobratest/spec/examples/letters/A/test.sh
 
 ## Todos
-* make algorithm work for structures where a gem is in a sub folder of another gem (only the inner gem should be diectly affected)
+* make algorithm work for structures where a gem is in a sub folder of another gem (only the inner gem should be directly affected)
 * allow for other test runners to be specified
-* optionally check for changes since origin/master
-* optionally allow branch to compare against to be specified
 
 ## License
 

--- a/bin/cobratest
+++ b/bin/cobratest
@@ -1,47 +1,45 @@
 #!/usr/bin/ruby
 
 require_relative "../lib/cobratest"
+require "optparse"
 
-def help_text
-  <<-USAGE
-cobratest [OPTION] [application path]
+options = {
+  display: "results",
+  path: nil
+}
 
-Test runner employing the structure of Component-based Ruby/Rails apps to optimize what needs to run.
+instructions = OptionParser.new do |opts|
+  opts.banner = "cobratest [OPTION] [application path]\n\n"
+  opts.separator "Test runner employing the structure of Component-based Ruby/Rails apps to optimize what needs to run.\n\n"
+  opts.separator "Options are...\n"
 
-Options are...
-    -h, -H, --help                   Display this help message.
-
-    -r, --results                    DEFAULT Display the directories of the components in need of running tests
-    -v, --verbose                    Verbose output of all parts of the calculation
-  USAGE
-end
-
-option = "-r"
-path = nil
-
-case ARGV.size
-  when 0
-  when 1
-    if ARGV[0].start_with? "-"
-      option = ARGV[0]
-    else
-      path = ARGV[0]
-    end
-  when 2
-    option = ARGV[0]
-    path = ARGV[1]
-  else
-    puts "Incorrect invocation. Please see help:\n\n"
-    puts help_text
-    exit 1
-end
-
-if option
-  if %w(--help -h -H).include? option
-    puts help_text
-  elsif %w(-r --results).include? option
-    Cbratest::Runner.new(false).run path
-  elsif %w(-v --verbose).include? option
-    Cbratest::Runner.new(true).run path
+  opts.on("-h", "-H", "--help", "Display this help message.") do
+    puts opts
+    exit
   end
+
+  opts.on("-r", "--results", "DEFAULT Display the directories of the components in need of running tests") do
+    options[:display] = "results"
+  end
+
+  opts.on("-v", "--verbose", "Verbose output of all parts of the calculation") do
+    options[:display] = "verbose"
+  end
+
+  opts.on("-s", "--since BRANCH", "Specify BRANCH target to calculate against") do |branch|
+    options[:since] = branch
+  end
+end
+
+begin
+  instructions.parse!
+  if ARGV.size >= 1
+    Cbratest::Runner.new(options).run ARGV[0]
+  else
+    raise OptionParser::MissingArgument.new("Must specify the application path")
+  end
+rescue OptionParser::InvalidOption, OptionParser::MissingArgument => error
+  puts error
+  puts instructions
+  exit
 end

--- a/lib/cobratest.rb
+++ b/lib/cobratest.rb
@@ -10,7 +10,7 @@ module Cbratest
   class Runner
     def initialize(opts)
       @verbose_output = opts[:display] == "verbose"
-      @since = opts[:since]
+      @since = opts[:since] || "current branch"
     end
 
     def run(root_path)
@@ -22,9 +22,9 @@ module Cbratest
       components = cobra_deps << app.to_s
       outputs component_out(components.to_a)
 
-      outputs "\nChanges since last commit"
+      outputs "\nChanges since last commit on #{@since}"
       root_dir = `cd #{path} && git rev-parse --show-toplevel`.chomp
-      if @since
+      if @since != "current branch"
         changes = `cd #{root_dir} && git diff --name-only #{@since}`.split("\n").map { |file| File.join(root_dir, file) }
       else
         changes = `cd #{root_dir} && git status -s -u`.split("\n").map { |file| File.join(root_dir, file.sub(/^.../, "")) }

--- a/spec/cobratest/cobratest_spec.rb
+++ b/spec/cobratest/cobratest_spec.rb
@@ -10,8 +10,9 @@ describe Cbratest do
 
   it "outputs all affected components in verbose mode" do
     start_path = File.expand_path(File.join(__FILE__, "..", "..", "..", "spec", "examples", "letters"))
+    options = { display: "verbose" }
 
-    Cbratest::Runner.new(true).run(File.join(start_path, 'A'))
+    Cbratest::Runner.new(options).run(File.join(start_path, 'A'))
     expect(@puts).to eq(
       [
         "All components",

--- a/spec/cobratest/cobratest_spec.rb
+++ b/spec/cobratest/cobratest_spec.rb
@@ -25,7 +25,7 @@ describe Cbratest do
           "F    #{start_path}/F",
           "A    #{start_path}/A"
         ],
-        "\nChanges since last commit",
+        "\nChanges since last commit on current branch",
         [],
         "\nDirectly affected components",
         [],

--- a/spec/cobratest/cobratest_spec.rb
+++ b/spec/cobratest/cobratest_spec.rb
@@ -36,4 +36,18 @@ describe Cbratest do
       ]
     )
   end
+
+  it "accepts alternative target branch, calculates based on last commit there" do
+    start_path = File.expand_path(File.join(__FILE__, "..", "..", "..", "spec", "examples", "letters"))
+    root_path = File.join(start_path, 'C')
+    root_dir = `cd #{root_path} && git rev-parse --show-toplevel`.chomp
+
+    since = "origin/master"
+    changes = `cd #{root_dir} && git diff --name-only #{since}`.split("\n").map { |file| File.join(root_dir, file) }
+    options = { display: "verbose", since: since }
+
+    Cbratest::Runner.new(options).run(root_path)
+    expect(@puts).to include("\nChanges since last commit on origin/master")
+    expect(@puts).to include(changes)
+  end
 end


### PR DESCRIPTION
Using the `--since` flag and passing it a branch (e.g. `master`) allows the user to display changes from the last commit on that specified branch.  All previous options and functionality are intact, and slightly more flexible with the use of Ruby's `OptionParser`.

Examples:
```bash
[Thu Apr 06 12:46:10]$ bin/cobratest -v . -s customize_gemfile_components_path
All components
.   .

Changes since last commit
/Users/garettarrowood/Power/cobratest/README.md
/Users/garettarrowood/Power/cobratest/bin/cobratest
/Users/garettarrowood/Power/cobratest/cobratest.gemspec
/Users/garettarrowood/Power/cobratest/lib/cobratest.rb
/Users/garettarrowood/Power/cobratest/lib/cobratest/gemfile_scraper.rb
/Users/garettarrowood/Power/cobratest/spec/cobratest/cobratest_spec.rb
/Users/garettarrowood/Power/cobratest/spec/cobratest/gemfile_scraper_spec.rb
/Users/garettarrowood/Power/cobratest/spec/examples/letters/B/Gemfile
/Users/garettarrowood/Power/cobratest/spec/examples/letters/B/b.gemspec
/Users/garettarrowood/Power/cobratest/spec/examples/letters/C/c.gemspec
/Users/garettarrowood/Power/cobratest/spec/examples/letters/D/Gemfile
/Users/garettarrowood/Power/cobratest/spec/examples/letters/D/d.gemspec
/Users/garettarrowood/Power/cobratest/spec/examples/letters/E1/e1.gemspec
/Users/garettarrowood/Power/cobratest/spec/examples/letters/E2/e2.gemspec
/Users/garettarrowood/Power/cobratest/spec/examples/letters/F/f.gemspec

Directly affected components

Transitively affected components

Test scripts to run

[Thu Apr 06 12:51:47]$ bin/cobratest -v . --since origin/master
All components
.   .

Changes since last commit
/Users/garettarrowood/Power/cobratest/README.md
/Users/garettarrowood/Power/cobratest/bin/cobratest
/Users/garettarrowood/Power/cobratest/lib/cobratest.rb
/Users/garettarrowood/Power/cobratest/spec/cobratest/cobratest_spec.rb

Directly affected components

Transitively affected components

Test scripts to run
```