### PR TITLE
Remove unused method and test

### DIFF
--- a/lib/cobratest/gemfile_scraper.rb
+++ b/lib/cobratest/gemfile_scraper.rb
@@ -14,13 +14,6 @@ module Cbratest
       {name: name, options: {path: @root_path}}
     end
 
-    def cobra_dependencies
-      dirdep = direct_dependencies
-      transitive_cobra_dependencies.select do |dep|
-        dirdep.include?(dep[:name]) || dep[:options][:direct]
-      end
-    end
-
     def transitive_cobra_dependencies
       gem_dependencies.inject([]) do |memo, dep|
         if !!dep[:options][:path]
@@ -33,19 +26,6 @@ module Cbratest
     end
 
     private
-
-    def raw_gemspec
-      path = File.expand_path(File.join(@root_path, "#{underscore(name)}.gemspec"))
-      File.exist?(path) ? File.read(path) : ""
-    end
-
-    def direct_dependencies
-      raw_gemspec.split("\n").inject([]) do |memo, line|
-        match = line.match(/add_(?:development_)?dependency\s+["']([^'"]+)["']/)
-        memo << match[1] if match
-        memo
-      end
-    end
 
     def gem_dependencies
       gemfile_path = File.join(@root_path, "Gemfile")
@@ -60,14 +40,6 @@ module Cbratest
         memo << { name: dep.name, options: { path: path }}
         memo
       end
-    end
-
-    def underscore(string)
-      string.gsub(/::/, '/').
-          gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2').
-          gsub(/([a-z\d])([A-Z])/, '\1_\2').
-          tr("-", "_").
-          downcase
     end
   end
 end

--- a/spec/cobratest/gemfile_scraper_spec.rb
+++ b/spec/cobratest/gemfile_scraper_spec.rb
@@ -5,23 +5,6 @@ describe Cbratest::GemfileScraper do
     expect(described_class.new("some/path_with/a/special_name").name).to eq "special_name"
   end
 
-  describe "#cobra_dependencies" do
-    it "returns an array of hashes of the runtime cobra_dependencies of a gem" do
-      start_path = File.expand_path(File.join(__FILE__, "..", "..", "..", "spec", "examples", "letters", "B"))
-      expected_path = File.expand_path(File.join(__FILE__, "..", "..", "..", "spec", "examples", "letters", "C"))
-
-      scraper = described_class.new(start_path)
-      expect(scraper.cobra_dependencies).to eq([
-                                                  {:name => "C",
-                                                   :options =>
-                                                       {
-                                                           :path => expected_path
-                                                       }
-                                                  }
-                                              ])
-    end
-  end
-
   describe "#transitive_cobra_dependencies" do
     it "returns an array of hashes of the all (transitive) cobra_dependencies" do
       start_path = File.expand_path(File.join(__FILE__, "..", "..", "..", "spec", "examples", "letters", "D"))


### PR DESCRIPTION
This PR was initially marked WIP, but is complete as it stands. The GemfileScraper class had an unused `cobra_dependencies` method, a test of this method, and some private methods specific to it. This commit simply removes them.